### PR TITLE
docs: add Phase 3A v0.2 planning specification

### DIFF
--- a/docs/SPINE_PHASE3A_v0.2_SPEC.md
+++ b/docs/SPINE_PHASE3A_v0.2_SPEC.md
@@ -1,0 +1,249 @@
+# SPINE Phase 3A Specification v0.2 (Planning)
+
+**Status:** Draft for planning and scope control only.  
+**Implementation state:** Not started. This document does **not** authorize or imply Phase 3A implementation work.
+
+---
+
+## 1) Why Phase 3A Exists
+
+SPINE v0.1 established and validated the core governance loop: mission control, bounded scope, opportunity scoring, brief generation, evidence and decision logging, drift scanning, and weekly review. Internal use and self-dogfooding confirmed this loop is real and useful.
+
+However, Phase 1–2 success does not yet guarantee smooth adoption on arbitrary repositories. v0.1.1 hardening highlighted practical operator friction: repo targeting ambiguity, branch context confusion, output ergonomics, and artifact discoverability.
+
+Phase 3A exists to solve those practical portability and operations gaps **before** any higher-surface expansion. This keeps SPINE aligned with its product thesis: governance reliability first, novelty later.
+
+This phase is intentionally positioned before dashboard/cloud/swarm directions to avoid repeating the same scope drift SPINE is designed to prevent.
+
+---
+
+## 2) Goals
+
+Phase 3A goals are narrow and operational:
+
+1. **Make SPINE portable across arbitrary repos** with explicit, predictable targeting semantics.
+2. **Reduce git-context ambiguity** by making active repo and branch context visible and reliable.
+3. **Increase operator confidence** through clear run-time context and deterministic command behavior.
+4. **Improve CI/automation friendliness** with machine-readable output and stable exit behavior where appropriate.
+5. **Tighten artifact ergonomics** with stable naming and path conventions that simplify inspection and automation.
+6. **Improve bootstrap clarity** for first use in non-SPINE repos.
+7. **Publish practical docs/examples** for adoption outside SPINE’s own repository.
+
+---
+
+## 3) Non-Goals
+
+Phase 3A explicitly excludes:
+
+- Dashboards, web UIs, or TUI visualization layers
+- Remote MCP transport/hosting
+- Hosted/cloud sync features
+- Authentication, billing, or account systems
+- Multi-user collaboration features
+- Autonomous orchestration/background agent loops
+- Broad adapter expansion or plugin matrix growth
+- Model-based scoring, model-based drift classification, or required live-model dependencies
+- Any Phase 4/5 roadmap work presented as active scope
+
+---
+
+## 4) Proposed Scope
+
+### 4.1 Explicit repo targeting
+
+**Why it matters**  
+Ambiguous working-directory behavior undermines trust and causes accidental writes to the wrong repo.
+
+**Problem solved**  
+Operators and CI need to intentionally direct SPINE at a specific repository path every time semantics matter.
+
+**Narrow acceptable implementation shape**  
+- Introduce and standardize explicit repo-targeting semantics (e.g., canonical path flag behavior) across Phase 3A-touched commands.
+- Normalize and display resolved target path during execution.
+- Fail fast with clear errors for invalid or non-repo targets when command requires git context.
+
+**Deferred**  
+- Repo discovery “magic” across arbitrary parent directories.
+- Multi-repo orchestration from one command invocation.
+
+### 4.2 Repo context and default-branch visibility
+
+**Why it matters**  
+Drift and review trust depend on operators knowing exactly which branch and comparison base are active.
+
+**Problem solved**  
+Implicit default-branch inference is useful but opaque without explicit reporting.
+
+**Narrow acceptable implementation shape**  
+- Standard context reporting format for relevant commands: target repo path, current HEAD branch/detached state, resolved default branch or explicit compare target.
+- Clear warning path when default branch cannot be resolved.
+- Keep behavior deterministic; prioritize transparent reporting over smart heuristics.
+
+**Deferred**  
+- Automatic branch remediation or branch-switching flows.
+- Advanced branch graph analytics.
+
+### 4.3 Operator/CI output modes (`--json`, `--quiet`, stable exits)
+
+**Why it matters**  
+Human-readable output is not sufficient for CI and scripts.
+
+**Problem solved**  
+Operators need parseable output and predictable exit codes.
+
+**Narrow acceptable implementation shape**  
+- Add machine-readable output mode where operationally justified.
+- Add reduced-noise output mode for healthy-path checks.
+- Define and document stable exit behavior for success, validation failures, and runtime/context failures.
+- Preserve deterministic semantics and backward-safe defaults.
+
+**Deferred**  
+- Event streaming, remote telemetry, or observability platforms.
+- Complex output formatting families beyond practical operator use.
+
+### 4.4 Artifact naming and path conventions
+
+**Why it matters**  
+Timestamp-only naming is difficult for quick navigation and scripting.
+
+**Problem solved**  
+Operators need both stable references and historical records.
+
+**Narrow acceptable implementation shape**  
+- Define canonical stable artifact aliases (for “current” assets) alongside history retention.
+- Standardize naming pattern(s) and directory layout expectations in docs.
+- Keep compatibility with existing artifact history where possible.
+
+**Deferred**  
+- Large artifact indexing systems.
+- Database-backed artifact catalogs.
+
+### 4.5 Bootstrap/install polish
+
+**Why it matters**  
+First-run experience determines adoption in non-SPINE repos.
+
+**Problem solved**  
+Initial setup should clearly communicate prerequisites, side effects, and resulting repo contract.
+
+**Narrow acceptable implementation shape**  
+- Improve bootstrap/install messaging and guidance for zero-context operators.
+- Clarify expected files, minimal workflow, and verification steps.
+- Keep install/bootstrap local-first and deterministic.
+
+**Deferred**  
+- Hosted installers, managed agents, or background services.
+
+### 4.6 Docs and examples for external repo usage
+
+**Why it matters**  
+v0.1 documents SPINE itself well, but operators need direct examples for adopting SPINE in unrelated repos.
+
+**Problem solved**  
+Reduce onboarding ambiguity and prevent misuse.
+
+**Narrow acceptable implementation shape**  
+- Add concise operator-grade examples for new/adopted repo flow.
+- Document explicit targeting patterns, branch context interpretation, and CI usage patterns.
+- Include anti-patterns and failure-mode examples.
+
+**Deferred**  
+- Broad cookbook ecosystems.
+- Framework-specific integration matrices.
+
+---
+
+## 5) Risks and Anti-Drift Notes
+
+Phase 3A drift risks and required guardrails:
+
+1. **Overbuilding operator UX**  
+   Risk: adding complex presentation layers instead of reliability improvements.  
+   Guardrail: prioritize explicit context and deterministic behavior over interface novelty.
+
+2. **Dashboard creep**  
+   Risk: introducing UI ambitions under the label of “visibility.”  
+   Guardrail: retain CLI + file-native governance as the core control surface.
+
+3. **Magical targeting**  
+   Risk: clever repo detection that surprises operators.  
+   Guardrail: explicit target resolution and clear reporting; avoid hidden fallbacks.
+
+4. **Surface growth before hygiene**  
+   Risk: adding new capability area before portability and release ergonomics are stable.  
+   Guardrail: phase gate requires operator-grade stability outcomes first.
+
+5. **Implicit Phase 4 pull-forward**  
+   Risk: “small” additions that become cloud/auth/collaboration foundations.  
+   Guardrail: enforce Non-Goals as hard exclusions for Phase 3A.
+
+---
+
+## 6) Acceptance Criteria
+
+Phase 3A is successful only if all of the following are true:
+
+1. **Explicit external repo targeting is operationally clear** and materially less ambiguous than v0.1 behavior.
+2. **Operators can always tell active context** (repo path, current branch state, comparison/default branch for relevant commands).
+3. **Machine-readable output is available where justified** and documented for CI use.
+4. **Exit behavior is stable and documented** for normal, validation, and context failures.
+5. **Artifact references become easier to inspect and automate** via stable naming/path conventions.
+6. **Bootstrap/install guidance is clearer for non-SPINE repos** with practical first-run expectations.
+7. **Documentation includes concrete external-repo examples** and anti-pattern warnings.
+8. **No prohibited surface expansion occurred** (dashboard/cloud/auth/billing/autonomous/multi-user/model-required scope).
+
+---
+
+## 7) Milestone Breakdown (Planning Sequence)
+
+### Phase 3A.1 — Spec finalization + explicit targeting design
+- Finalize Phase 3A boundaries and command-level targeting contract.
+- Define context-reporting contract fields and error semantics.
+- Lock non-goals and drift guardrails.
+
+### Phase 3A.2 — Repo-context clarity
+- Implement and validate consistent repo/branch/default-branch visibility on relevant commands.
+- Ensure deterministic handling of unresolved default branch states.
+
+### Phase 3A.3 — Operator/CI output polish
+- Add machine-readable and quiet output modes where justified.
+- Publish stable exit-code behavior and update operator docs.
+- Validate scripting reliability in representative local/CI scenarios.
+
+### Phase 3A.4 — Artifact + docs completion
+- Finalize stable artifact naming/path conventions.
+- Publish external-repo onboarding and usage examples.
+- Run final portability validation pass before Phase 3A closeout.
+
+---
+
+## 8) Recommended First Slice (when implementation is approved)
+
+**Recommended first implementation slice:**  
+**Explicit repo targeting + clear repo/branch/default-branch context reporting.**
+
+**Why first:**
+- Highest risk-reduction per unit effort.
+- Directly addresses correctness and operator trust issues identified in dogfooding.
+- Creates the foundation required for meaningful `--json`, CI integration, and artifact ergonomics.
+- Prevents follow-on work from inheriting ambiguous targeting behavior.
+
+This first slice should remain narrow: no new product surfaces, no remote capabilities, and no speculative architecture.
+
+---
+
+## 9) Relation to Current State
+
+This Phase 3A planning spec is a direct continuation of:
+
+- **SPINE Official Spec v0.1:** establishes the core governance contract and non-goal posture.
+- **SPINE Origin and Product Thesis v0.1:** reinforces SPINE’s role as governance above agents and warns against becoming a sprawl machine.
+- **SPINE v0.1.1 Self-Dogfood Cleanup:** surfaces practical operator friction and hardening insights that motivate portability/polish as the next maturity step.
+- **External validation gate:** remains the real-world progression criterion; Phase 3A is scoped to improve reliability and usability for that gate, not bypass it.
+
+---
+
+## 10) Planning Status Note
+
+Phase 3A is currently **specified, not approved for implementation in this document**.  
+Any implementation must be separately authorized and executed as a bounded follow-on phase.


### PR DESCRIPTION
Closing this PR — it targets a deprecated branch (claude/spine-phase-1-init-hOwIP) that is being retired as part of the public alpha cleanup. The work was integrated into prep/v0.1.1-alpha and main. No action needed.